### PR TITLE
fix: Check for /mosquito subdirectories existence before creating them

### DIFF
--- a/mosquitto/templates/deploy.yaml
+++ b/mosquitto/templates/deploy.yaml
@@ -66,6 +66,10 @@ spec:
             - -ex
             - -c
             - |
+              if [ -d /mosquitto/config/ ]; then
+                echo "Directory /mosquitto/config/ already exists. Exiting with success."
+                exit 0
+              fi
               mkdir /mosquitto/config/ &&
               cp /config/mosquitto.conf /mosquitto/config/ &&
               chmod -R 777 /mosquitto
@@ -83,6 +87,10 @@ spec:
             - -ex
             - -c
             - |
+              if [ -d /mosquitto/auth/ ]; then
+                echo "Directory /mosquitto/auth/ already exists. Exiting with success."
+                exit 0
+              fi
               mkdir /mosquitto/auth/ &&
               cp /aux/passwd /mosquitto/auth/ &&
               chmod 0700 /mosquitto/auth/passwd &&
@@ -101,6 +109,10 @@ spec:
             - -ex
             - -c
             - |
+              if [ -d /mosquitto/certs/ ]; then
+                echo "Directory /mosquitto/certs/ already exists. Exiting with success."
+                exit 0
+              fi
               mkdir /mosquitto/certs/ &&
               cp /cert/default.pem /mosquitto/certs/ &&
               chown 1000:1000 /mosquitto/certs/default.pem &&


### PR DESCRIPTION
Buenas,

Soy un alumno del grado de Ing. Informática de la UMA. Estoy realizando mi TFG bajo la cotutorización de Julia, en este utilizo la plataforma de OpenTwins.

Detecté un error en el helm de OpenTwins que provoca que el pod de mosquitto caiga en algunas ocasiones, como al reiniciar el cluster, quedandose este en estado "Unknown". He depurado este error y llegado a la causa: **los initContainers fallan al tratar de crear directorios que ya existen**, el comando mkdir arroja un codigo de error distinto de 0, por ende kubernetes considera que el contenedor ha fallado y lo reinicia, el fallo se repite en bucle y el pod queda inutilizable. Adjunto una captura donde se puede apreciar el error con claridad, en este caso en el container `setup-config`, el primero en ejecutarse:
![image](https://github.com/user-attachments/assets/ffac8651-bb93-4dfc-bedf-676e64e4e00e)

Mi propuesta de solución es simple: comprobar si el directorio que provoca el fallo al intentar crearse existe, si es así se realiza un `exit 0` para indicarle a kubernetes que el contenedor ha terminado su ejecución de forma exitosa. He probado desplegando en mi cluster local y reiniciandolo su único nodo, antes siempre quedaba el pod en estado Unknown, con el fix implementado deja de ocurrir.